### PR TITLE
Adding "environments" configuration option (issue #74)

### DIFF
--- a/lib/asset_sync.rb
+++ b/lib/asset_sync.rb
@@ -1,10 +1,9 @@
 require 'fog'
 require 'active_model'
 require 'erb'
-require "asset_sync/asset_sync"
 require 'asset_sync/config'
+require "asset_sync/asset_sync"
 require 'asset_sync/storage'
-
 
 require 'asset_sync/railtie' if defined?(Rails)
 require 'asset_sync/engine'  if defined?(Rails)

--- a/lib/asset_sync/engine.rb
+++ b/lib/asset_sync/engine.rb
@@ -16,6 +16,8 @@ class Engine < Rails::Engine
         config.fog_directory = ENV['FOG_DIRECTORY']
         config.fog_region = ENV['FOG_REGION']
 
+        config.environments = %w(production staging)
+
         config.aws_access_key_id = ENV['AWS_ACCESS_KEY_ID']
         config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
 

--- a/lib/generators/asset_sync/templates/asset_sync.rb
+++ b/lib/generators/asset_sync/templates/asset_sync.rb
@@ -16,7 +16,10 @@ AssetSync.configure do |config|
   # config.rackspace_auth_url = "lon.auth.api.rackspacecloud.com"
   <%- end -%>
   config.fog_directory = ENV['FOG_DIRECTORY']
-  
+
+  # Environments which will have AssetSync enabled
+  config.environments = %w(production staging)
+
   # Increase upload performance by configuring your region
   # config.fog_region = 'eu-west-1'
   #
@@ -26,7 +29,7 @@ AssetSync.configure do |config|
   # Automatically replace files with their equivalent gzip compressed version
   # config.gzip_compression = true
   #
-  # Use the Rails generated 'manifest.yml' file to produce the list of files to 
+  # Use the Rails generated 'manifest.yml' file to produce the list of files to
   # upload instead of searching the assets directory.
   # config.manifest = true
   #

--- a/spec/aws_with_yml/config/asset_sync.yml
+++ b/spec/aws_with_yml/config/asset_sync.yml
@@ -13,6 +13,7 @@ test:
   <<: *defaults
   fog_directory: "rails_app_test"
   existing_remote_files: keep
+  enabled: true
 
 production:
   <<: *defaults

--- a/spec/google_spec.rb
+++ b/spec/google_spec.rb
@@ -85,8 +85,9 @@ describe AssetSync do
       AssetSync.config = AssetSync::Config.new
     end
 
-    it "should be invalid" do
-      lambda{ AssetSync.sync }.should raise_error(AssetSync::Config::Invalid)
+    it "should default to disabled" do
+      AssetSync.should_not be_enabled
+      lambda{ AssetSync.sync }.should_not raise_error(AssetSync::Config::Invalid)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,6 @@ shared_context "mock without Rails" do
   end
 end
 
-
 shared_context "mock Rails" do
   before(:each) do
     unless defined? Rails


### PR DESCRIPTION
Adding "environments" configuration option to explicitly declare under which Rails environments AssetSync should be enabled.

- This option defaults to ["production", "staging"]
- This option can be overriden by setting the "enabled" option in the desired environment of the yaml file.
- Other environments different from production and staging are disabled by default, unless explicitly declared otherwise.

This references: https://github.com/rumblelabs/asset_sync/issues/74